### PR TITLE
Fix jump to last unread in forums arrow not appearing

### DIFF
--- a/style.css
+++ b/style.css
@@ -1077,7 +1077,7 @@ tr.likes td {text-align: left !important;}					/*Left aligns the like/dislike te
 
 table.forum_index {											/* Sets background of main forum page */
     background: url('https://gazellegames.net/static/styles/blue_ambrose/images/companioncube.png') repeat-y scroll bottom right !important;
-	ackground-size: 100% auto;
+	background-size: 100% auto; /*Dieslrae fix #4 - typo causing forum index sizing to be improper and losing jump to last unread arrow on some threads. */
     border: 1px solid #036;}
 
 #forums #content .thin table {								/*Background of forum sections*/


### PR DESCRIPTION
Typo causing forum index sizing to be improper and losing jump to last unread arrow on some threads. Works in original Blue Ambrose, so must've been introduced by fixes #1-3 somewhere.